### PR TITLE
[packaging] Add spec files for ansible roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
 # osp-observability-ansible
 
-Ansible playbooks to deploy and configure client side services (Collectd,
-Ceilometer, QDR etc.) on OSP nodes.
+Spec files for packaging STF client side ansible roles.
 
-Currently PoC, with some debugging info for test-role, which displays the
-params passed from TripleO to the ansible playbook.
+## Instructions for testing
 
-## Setup
-
-Install dependencies via `ansible-galaxy`.
+1. Instantiate your build environment, according to https://rpm-packaging-guide.github.io/#rpm-packaging-workspace
 
 ```
-ansible-galaxy install -r requirements.yml --roles-path ./roles/
+   rpmdev-setuptree
+```
+
+2. Download the source files into your build environment
+
+```
+   spectool -g --define 'upstream_version master' --directory rpmbuild/SOURCES/ osp-observability-ansible/collectd-config-ansible-role.spec
+   spectool -g --define 'upstream_version master' --directory rpmbuild/SOURCES/ osp-observability-ansible/qdr-config-ansible-role.spec
+```
+
+3. Build the rpms, according to https://rpm-packaging-guide.github.io/#binary-rpms
+
+```
+   rpmbuild -bb --define 'upstream_release master' osp-observability-ansible/collectd-config-ansible-role.spec
+   rpmbuild -bb --define 'upstream_release master' osp-observability-ansible/qdr-config-ansible-role.spec
+
+```
+
+4.
+```
+   sudo dnf install rpmbuild/RPMS/noarch/ansible-collectd-config-0.1-1.noarch.rpm
+   sudo dnf install rpmbuild/RPMS/noarch/ansible-qdr-config-0.1-1.noarch.rpm
+```
+
+Alternatively, you can use mock, and rplace steps 3 and 4 above:
+
+3.
+```
+rpmbuild -bs --define 'upstream_release master' osp-observability-ansible/qdr-config-ansible-role.spec
+```
+
+4.
+```
+  sudo mock -r epel-7-x86_64 ~/rpmbuild/SRPMS/ansible-qdr-config-master-1.src.rpm
 ```

--- a/collectd-config-ansible-role.spec
+++ b/collectd-config-ansible-role.spec
@@ -1,0 +1,44 @@
+%global srcname collectd_config_ansible_role
+%global rolename collectd-config
+
+%{!?upstream_version: %global upstream_version %{version}%{?milestone}}
+
+Name:           ansible-%{rolename}
+Version:        master
+Release:        1
+Summary:        Ansible role for creating collectd configs
+
+Group:          TODO
+License:        ASL 2.0
+URL:            https://github.com/infrawatch/collectd-config-ansible-role
+Source0:        https://github.com/infrawatch/collectd-config-ansible-role/archive/%{upstream_version}/collectd-config-ansible-role-%{upstream_version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  git-core
+
+Requires:       python3dist(ansible)
+
+%description
+
+Ansible role for creating collectd configs
+
+%prep
+%autosetup -n collectd-config-ansible-role-%{upstream_version} -S git
+
+
+%build
+
+
+%install
+mkdir -p  %{buildroot}%{_datadir}/ansible/roles/collectd_config
+cp -r ./* %{buildroot}%{_datadir}/ansible/roles/collectd_config
+
+
+%files
+%doc README*
+%license LICENSE
+%{_datadir}/ansible/roles/collectd_config
+%exclude %{_datadir}/ansible/role/collectd_config/tests/*
+
+%changelog
+

--- a/qdr-config-ansible-role.spec
+++ b/qdr-config-ansible-role.spec
@@ -1,0 +1,43 @@
+%global srcname qdr_config_ansible_role
+%global rolename qdr-config
+
+%{!?upstream_version: %global upstream_version %{version}%{?milestone}}
+
+Name:           ansible-%{rolename}
+Version:        master
+Release:        1
+Summary:        Ansible role for creating qdr configs
+
+Group:          TODO
+License:        ASL 2.0
+URL:            https://github.com/infrawatch/qdr-config-ansible-role
+Source0:        https://github.com/infrawatch/qdr-config-ansible-role/archive/%{upstream_version}/qdr-config-ansible-role-%{upstream_version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  git-core
+
+Requires:       python3dist(ansible)
+
+%description
+
+Ansible role for creating qdr configs
+
+%prep
+%autosetup -n qdr-config-ansible-role-%{upstream_version} -S git
+
+
+%build
+
+
+%install
+mkdir -p  %{buildroot}%{_datadir}/ansible/roles/qdr_config
+cp -r ./* %{buildroot}%{_datadir}/ansible/roles/qdr_config
+
+
+%files
+%doc README*
+%license LICENSE
+%{_datadir}/ansible/roles/qdr_config
+
+%changelog
+


### PR DESCRIPTION
Initial spec files for packaging collectd-config-ansible-roles and
qdr-config-ansible-roles.

The packages are not archived upstream yet, so instructions are
included for testing these "from source" (rather than from archive)
locally.
It is expected that when the repos are archived upstream, this will
just work without needing to archive the repos locally, as long as
the naming format in Source0 is correct.