### PR TITLE
Fixes to make prometheus actually work

### DIFF
--- a/playbooks/prometheus_agent.yml
+++ b/playbooks/prometheus_agent.yml
@@ -33,8 +33,8 @@
         name: "{{ container_name }}"
         image: "{{ container_image }}"
         volumes:
-          - "{{ prometheus_config_dir }}:/data:rw,z"
-          - "{{ prometheus_data_dir }}:/etc/prometheus:ro,z"
+          - "{{ prometheus_config_dir }}:/etc/prometheus:ro,z"
+          - "{{ prometheus_data_dir }}:/data:rw,z"
         command: >
           --enable-feature=agent
           --config.file=/etc/prometheus/prometheus.yml

--- a/roles/osp_observability/tasks/configure_prometheus.yml
+++ b/roles/osp_observability/tasks/configure_prometheus.yml
@@ -2,8 +2,8 @@
 
 - name: Expose created Prometheus agent directories
   ansible.builtin.set_fact:
-    prometheus_config_dir: "{{ prometheus_config_basedir }}/data"
-    prometheus_data_dir: "{{ prometheus_config_basedir }}/etc/prometheus"
+    prometheus_config_dir: "{{ prometheus_config_basedir }}/etc/prometheus"
+    prometheus_data_dir: "{{ prometheus_config_basedir }}/data"
 
 - name: Prepare configuration and data directory for Prometheus agent
   ansible.builtin.file:

--- a/roles/osp_observability/templates/prometheus.yml.j2
+++ b/roles/osp_observability/templates/prometheus.yml.j2
@@ -1,17 +1,18 @@
+#jinja2: trim_blocks:False
 global:
   scrape_interval: {{ prometheus_scrape_interval }}
   external_labels:
-    {%- if ansible_fqdn %}agent_host: {{ ansible_fqdn }}{% endif %}
-    {%- if openstack_cloud_name %}cloud_name: {{ openstack_cloud_name }}{% endif -%}
+    {% if ansible_fqdn %}agent_host: {{ ansible_fqdn }}{% endif %}
+    {% if openstack_cloud_name %}cloud_name: {{ openstack_cloud_name }}{% endif %}
 
 scrape_configs:
 {%- for service, nodes in scrape_endpoints.items() %}
   - job_name: {{ service }}
     static_configs:
       - targets: {{ nodes }}
-{% endfor %}
+{%- endfor %}
 
 remote_write:
-{% for url in remote_write %}
+{% for url in remote_write -%}
   - url: {{ url }}
 {% endfor %}


### PR DESCRIPTION
When I ran the original code I got this: 

```
ts=2022-12-01T18:58:43.747Z caller=main.go:187 level=info msg="Experimental agent mode enabled."
ts=2022-12-01T18:58:43.747Z caller=main.go:468 level=error msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" file=/etc/prometheus/prometheus.yml err="open /etc/prometheus/prometheus.yml: no such file or directory"
```

So I fixed the paths.

Unfortunately, while the config file exists now, it looks like this:
```
global:
  scrape_interval: 1s
  external_labels:agent_host: controller-0.csibb17cloud_name: overcloudscrape_configs:
remote_write:
  - url: http://someurl
  - url: http://otherurl
```

And generates this new error:
```
ts=2022-12-01T19:55:21.187Z caller=main.go:468 level=error msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" file=/etc/prometheus/prometheus.yml err="parsing YAML file /etc/prometheus/prometheus.yml: yaml: line 3: mapping values are not allowed in this context"
```
