### PR TITLE
Fix scrape endpoints and whitespace when iterating

### DIFF
--- a/playbooks/prometheus_agent.yml
+++ b/playbooks/prometheus_agent.yml
@@ -14,8 +14,8 @@
     - name: Include scrape endpoints file
       ansible.builtin.include_vars:
         file: "{{ scrape_config }}"
-        name: scrape_endpoints
-    - debug: msg="the value of scrape_endpoints is {{ scrape_endpoints }}"
+        name: prometheus_scrape_endpoints
+    - debug: msg="the value of prometheus_scrape_endpoints is {{ prometheus_scrape_endpoints }}"
     - name: Provide Prometheus agent configuration
       include_role:
         name: /usr/share/ansible/roles/osp_observability

--- a/roles/osp_observability/templates/prometheus.yml.j2
+++ b/roles/osp_observability/templates/prometheus.yml.j2
@@ -7,14 +7,14 @@ global:
 {% endif %}
 
 scrape_configs:
-  {% for service, nodes in prometheus_scrape_endpoints.items() -%}
+{% for service, nodes in prometheus_scrape_endpoints.items() %}
   - job_name: {{ service }}
     static_configs:
       - targets: {{ nodes }}
 {% endfor %}
 
 remote_write:
-  {% for name, endpoint in prometheus_remote_write.items() -%}
+{% for name, endpoint in prometheus_remote_write.items() %}
   - url: {{ endpoint.url }}
     {% if endpoint.basic_user is defined and endpoint.basic_pass is defined -%}
     basic_auth:
@@ -27,6 +27,6 @@ remote_write:
       server_name: {{ endpoint.url | regex_search('^https://(.*?)/', '\\1') | first }}
       {% if endpoint.ca_cert is defined -%}
       ca_file: /etc/prometheus/{{ name }}_CA.pem
+{% endif -%}
 {%- endif -%}
-{%- endif -%}
-{%- endfor -%}
+{% endfor -%}


### PR DESCRIPTION
I was trying to add multiple scrape endpoints and targets, and ran into trouble.

It looks like I broke the scrape endpoints with a previous PR (sorry - playbook is not covered by CI tests). This fixes it, and also fixes problems with whitespace while iterating.

Before
```
scrape_configs:
  - job_name: collectd
    static_configs:
      - targets: ['localhost:9103']
```

After
```
scrape_configs:
  - job_name: collectd
    static_configs:
      - targets: ["192.168.24.30:9103"]
  - job_name: target1
    static_configs:
      - targets: ["192.168.24.30:8001"]
  - job_name: target2
    static_configs:
      - targets: ["192.168.24.30:8002"]
  - job_name: target3
    static_configs:
      - targets: ["192.168.24.30:8003"]
```

I cleaned up the remote_write whitespace while iterating as well:

```
remote_write:
  - url: https://default-prometheus-proxy-service-telemetry.apps.cluster/api/v1/write
    basic_auth:
      username: internal
      password: password
    tls_config:
```

Patches welcome to expand molecule testing to cover multiple scrape and remote_write targets.
