### PR TITLE
[galaxy] Add a buid_ignore section for collection packaging

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,4 +11,8 @@ tags:
     - openstack
     - osp
 repository: "https://www.github.com/infrawatch/osp-observability-ansible"
+build_ignore:
+  - "tools"
+  - ".*"
+  - "*/.*"
 


### PR DESCRIPTION
Instead of trying to remove these files during rpm packaging, they should be removed using the build_ignore flag.

[1] https://review.rdoproject.org/r/c/openstack/ansible-role-osp-observability-distgit/+/46273/13/ansible-role-osp-observability.spec#28 [2] https://docs.fedoraproject.org/en-US/packaging-guidelines/Ansible_collections/#_unnecessary_files